### PR TITLE
Update mail to at least 2.5.5

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.add_dependency "actionview", version
   s.add_dependency "activejob", version
 
-  s.add_dependency "mail", ["~> 2.5", ">= 2.5.4"]
+  s.add_dependency "mail", ["~> 2.5", ">= 2.5.5"]
   s.add_dependency "rails-dom-testing", "~> 2.0"
 end


### PR DESCRIPTION
to avoid CVE-2015-9097 - see mikel/mail#1097


